### PR TITLE
Add a workflow for 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Gradle build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, "1.17" ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, "1.17" ]
 
 jobs:
   build:
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 16
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
When using the template, it's annoying to have the build fail due to using an incorrect version of Java.