### PR TITLE
Improve build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Gradle build
+name: Build with Gradle
 
 on:
   push:
@@ -8,15 +8,18 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [17] # This is for easier updating in the future if MC updates Java again
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
+        distribution: temurin
+        cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java: [17] # This is for easier updating in the future if MC updates Java again
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin


### PR DESCRIPTION
This adds a matrix, to make MC updating Java easier, updates Java to 17 (as it was 1.8 lol), adds the `cache` parameter to the setup java step (This should improve build time), and updates the various actions to the latest stable versions.

Closes #12, as is no longer relevant if this is merged.